### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/app.js
+++ b/app.js
@@ -332,6 +332,17 @@ function toggleReceived(expenseId) {
     }
 }
 
+// Utility to escape HTML special characters
+function escapeHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/`/g, '&#96;');
+}
+
 function loadRecentExpenses() {
     const history = JSON.parse(localStorage.getItem('expenseHistory') || '[]');
     const container = document.getElementById('recent-expenses');
@@ -350,7 +361,7 @@ function loadRecentExpenses() {
         return `
             <div class="recent-item ${receivedClass}">
                 <div class="recent-header">
-                    <div class="recent-description">${expense.description}</div>
+                    <div class="recent-description">${escapeHtml(expense.description)}</div>
                     <div class="status-container">
                         <span class="status-icon">${statusIcon}</span>
                         <label class="checkbox-container">

--- a/app.js
+++ b/app.js
@@ -334,6 +334,7 @@ function toggleReceived(expenseId) {
 
 // Utility to escape HTML special characters
 function escapeHtml(str) {
+    if (str == null) return '';
     return String(str)
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')


### PR DESCRIPTION
Potential fix for [https://github.com/hsk-dk/kvittering-app/security/code-scanning/3](https://github.com/hsk-dk/kvittering-app/security/code-scanning/3)

To fix this vulnerability, we need to ensure that any user-supplied data (such as `expense.description`) is properly escaped before being inserted into the DOM as HTML. The best way to do this is to escape special HTML characters (`&`, `<`, `>`, `"`, `'`, and `` ` ``) in the description before including it in the template literal. This can be achieved by creating a utility function (e.g., `escapeHtml`) that performs this escaping, and then using it whenever rendering user-supplied data into HTML.

Specifically, in `loadRecentExpenses`, we should replace `${expense.description}` with `${escapeHtml(expense.description)}`. The `escapeHtml` function should be defined in the same file, above its first use.

No changes to imports are needed, as this can be implemented with a simple utility function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
