### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/app.js
+++ b/app.js
@@ -182,6 +182,12 @@ function saveSettings() {
     alert('Indstillinger gemt!');
 }
 
+// Helper function to validate email addresses
+function isValidEmail(email) {
+    // Simple email regex for basic validation
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
 // Send expense
 async function sendExpense() {
     const description = document.getElementById('description').value;
@@ -199,6 +205,10 @@ async function sendExpense() {
     
     if (!settings.treasurerEmail) {
         alert('Kassererens e-mail er ikke indstillet. Gå til indstillinger først.');
+        return;
+    }
+    if (!isValidEmail(settings.treasurerEmail)) {
+        alert('Kassererens e-mail er ugyldig. Indtast en gyldig e-mailadresse.');
         return;
     }
     
@@ -230,7 +240,7 @@ async function sendExpense() {
     }
     
     // Fallback: use mailto link and offer to download images
-    const mailtoLink = `mailto:${settings.treasurerEmail}?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(emailBody)}`;
+    const mailtoLink = `mailto:${encodeURIComponent(settings.treasurerEmail)}?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(emailBody)}`;
     window.location.href = mailtoLink;
     
     // Provide option to download images for manual attachment

--- a/app.js
+++ b/app.js
@@ -185,6 +185,9 @@ function saveSettings() {
 // Helper function to validate email addresses
 function isValidEmail(email) {
     // Simple email regex for basic validation
+    if (typeof email !== 'string' || !email.trim()) {
+        return false;
+    }
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/hsk-dk/kvittering-app/security/code-scanning/2](https://github.com/hsk-dk/kvittering-app/security/code-scanning/2)

To fix this problem, we need to ensure that the email address used in the `mailto:` link is properly sanitized and validated before being inserted into the URL. The best way to do this is to validate that the input is a well-formed email address before using it. This can be done using a regular expression or by using a library function. Additionally, we should encode the email address using `encodeURIComponent` to ensure that any special characters are safely encoded.

Specifically, in `sendExpense()`, before constructing the `mailtoLink`, we should validate `settings.treasurerEmail`. If it is not a valid email address, we should alert the user and abort. When constructing the `mailto:` URL, we should use `encodeURIComponent` on the email address as well as the subject and body (the latter is already being encoded).

The changes should be made in `app.js`:
- Add a helper function to validate email addresses.
- In `sendExpense()`, before constructing the `mailto:` link, validate the email address.
- Use `encodeURIComponent` on the email address when constructing the `mailto:` link.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
